### PR TITLE
Make sqlite3ext optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,58 +14,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.69.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "a4c69fae65a523209d34240b60abe0c42d33d1045d445c0839d8a4894a736e2d"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.2",
  "cexpr",
  "clang-sys",
- "clap",
- "env_logger",
  "lazy_static",
  "lazycell",
- "log",
  "peeking_take_while",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "which",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -116,49 +87,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "3.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_lex",
- "indexmap",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "either"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
-
-[[package]]
-name = "env_logger"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,12 +106,6 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
@@ -198,32 +120,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
 dependencies = [
- "hashbrown 0.14.0",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -272,15 +169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "log"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,12 +197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
-
-[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,18 +210,18 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -350,8 +232,6 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -404,7 +284,7 @@ checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -449,7 +329,7 @@ version = "0.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -458,12 +338,6 @@ version = "0.0.1"
 dependencies = [
  "bindgen",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -477,19 +351,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
+name = "syn"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
- "winapi-util",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "unicode-ident"
@@ -510,17 +380,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "which"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
-dependencies = [
- "either",
- "libc",
- "once_cell",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,15 +394,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["sqlite"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-sqlite3ext-sys = {version="0.0.1", path="./sqlite3ext-sys"}
+sqlite3ext-sys = {version="0.0.1", optional = true, path="./sqlite3ext-sys"}
 sqlite-loadable-macros={version="0.0.3", path="./sqlite-loadable-macros"}
 serde = {version="1.0.147", features = ["derive"]}
 serde_json = "1.0.87"
@@ -22,6 +22,8 @@ rusqlite = "0.29.0"
 libsqlite3-sys = {version="0.26.0", default-features = false, features=["bundled"]}
 
 [features]
+default = ["dynamic"]
+dynamic = ["sqlite3ext-sys"]
 static = ["libsqlite3-sys"]
 exec = []
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -41,7 +41,7 @@ Though there's no `crate_type="cdylib"` macro we can use, so gotta introduce a n
 pub unsafe fn sqlite3ext_user_data2(context: *mut sqlite3_context) -> *mut c_void {
     libsqlite3_sys::sqlite3_user_data(context)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_user_data2(context: *mut sqlite3_context) -> *mut c_void {
     ((*SQLITE3_API).user_data.expect(EXPECT_MESSAGE))(context)
 }
@@ -58,7 +58,7 @@ macro_rules! export_sqlite_function {
           concat_idents!(libsqlite3_sys::, sqlite3_, $func)(context)
         }
 
-        #[cfg(not(feature = "static"))]
+        #[cfg(all(not(feature = "static"), feature = "dynamic"))]
         pub unsafe fn $func(context: *mut sqlite3_context) -> *mut c_void {
             ((*SQLITE3_API).$func.expect(EXPECT_MESSAGE))(context)
         }
@@ -99,7 +99,7 @@ make sqlite3_wasm_extra_init.c=../../../../target/wasm32-unknown-emscripten/debu
 
 //#[cfg(target_os = "emscripten")]
 pub extern "C" fn sqlite3_wasm_extra_init(_unused: *const std::ffi::c_char) -> std::ffi::c_int {
-    use sqlite_loadable::SQLITE_OKAY;
+    use sqlite_loadable::SQLITE_OK;
     println!("sqlite3_wasm_extra_init");
     unsafe {
         sqlite_loadable::ext::sqlite3ext_auto_extension(std::mem::transmute(
@@ -107,7 +107,7 @@ pub extern "C" fn sqlite3_wasm_extra_init(_unused: *const std::ffi::c_char) -> s
         ));
     }
 
-    SQLITE_OKAY
+    SQLITE_OK
 }
 
 ```

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -30,12 +30,12 @@ pub fn sqlite3_hello_init(db: *mut sqlite3) -> Result<()> {
 #[cfg(target_os = "emscripten")]
 #[no_mangle]
 pub extern "C" fn sqlite3_wasm_extra_init(_unused: *const std::ffi::c_char) -> std::ffi::c_int {
-    use sqlite_loadable::SQLITE_OKAY;
+    use sqlite_loadable::SQLITE_OK;
     unsafe {
         sqlite_loadable::ext::sqlite3ext_auto_extension(std::mem::transmute(
             sqlite3_hello_init as *const (),
         ));
     }
 
-    SQLITE_OKAY
+    SQLITE_OK
 }

--- a/sqlite-loadable-macros/src/lib.rs
+++ b/sqlite-loadable-macros/src/lib.rs
@@ -33,7 +33,7 @@ pub fn sqlite_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     db: *mut sqlite3,
                     pz_err_msg: *mut *mut c_char,
                     p_api: *mut sqlite3_api_routines,
-                ) -> c_uint {
+                ) -> c_int {
                     register_entrypoint(db, pz_err_msg, p_api, #prefixed_original_function)
                 }
 
@@ -73,7 +73,7 @@ pub fn sqlite_entrypoint_permanent(_attr: TokenStream, item: TokenStream) -> Tok
                     db: *mut sqlite3,
                     pz_err_msg: *mut *mut c_char,
                     p_api: *mut sqlite3_api_routines,
-                ) -> c_uint {
+                ) -> c_int {
                     register_entrypoint_load_permanently(db, pz_err_msg, p_api, #prefixed_original_function)
                 }
 

--- a/sqlite3ext-sys/Cargo.toml
+++ b/sqlite3ext-sys/Cargo.toml
@@ -12,4 +12,4 @@ license = "MIT/Apache-2.0"
 [dependencies]
 
 [build-dependencies]
-bindgen = "0.60.1"
+bindgen = {version = "0.69", default-features = false, features = ["runtime"]}

--- a/sqlite3ext-sys/build.rs
+++ b/sqlite3ext-sys/build.rs
@@ -16,9 +16,12 @@ fn main() {
     */
     println!("cargo:rerun-if-changed=wrapper.h");
 
-    let bindings = bindgen::Builder::default()
+    let bindings = bindgen::builder()
+        .default_macro_constant_type(bindgen::MacroTypeVariation::Signed)
+        .disable_nested_struct_naming()
+        .trust_clang_mangling(false)
         .header("sqlite3/sqlite3ext.h")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,7 +5,9 @@
 //! Useful when working with sqlite3_value or sqlite3_context.
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
-use crate::constants::SQLITE_OKAY;
+use crate::constants::{
+    SQLITE_BLOB, SQLITE_FLOAT, SQLITE_INTEGER, SQLITE_NULL, SQLITE_OK, SQLITE_TEXT,
+};
 use crate::ext::{
     sqlite3, sqlite3_context, sqlite3_value, sqlite3ext_context_db_handle, sqlite3ext_get_auxdata,
     sqlite3ext_mprintf, sqlite3ext_overload_function, sqlite3ext_result_blob,
@@ -17,7 +19,6 @@ use crate::ext::{
     sqlite3ext_value_subtype, sqlite3ext_value_text, sqlite3ext_value_type,
 };
 use crate::Error;
-use sqlite3ext_sys::{SQLITE_BLOB, SQLITE_FLOAT, SQLITE_INTEGER, SQLITE_NULL, SQLITE_TEXT};
 use std::os::raw::c_int;
 use std::slice::from_raw_parts;
 use std::str::Utf8Error;
@@ -211,7 +212,7 @@ pub enum ValueType {
 pub fn value_type(value: &*mut sqlite3_value) -> ValueType {
     let raw_type = unsafe { sqlite3ext_value_type(value.to_owned()) };
     // "as u32" because bindings for constants are u32 for some reason???
-    match raw_type as u32 {
+    match raw_type {
         SQLITE_TEXT => ValueType::Text,
         SQLITE_INTEGER => ValueType::Integer,
         SQLITE_FLOAT => ValueType::Float,
@@ -225,7 +226,7 @@ pub fn value_type(value: &*mut sqlite3_value) -> ValueType {
 }
 pub fn value_is_null(value: &*mut sqlite3_value) -> bool {
     let raw_type = unsafe { sqlite3ext_value_type(value.to_owned()) };
-    (raw_type as u32) == SQLITE_NULL
+    raw_type == SQLITE_NULL
 }
 
 pub fn value_subtype(value: &*mut sqlite3_value) -> u32 {
@@ -397,7 +398,7 @@ pub fn context_db_handle(context: *mut sqlite3_context) -> *mut sqlite3 {
 pub fn overload_function(db: *mut sqlite3, func_name: &str, n_args: i32) -> crate::Result<()> {
     let cname = CString::new(func_name)?;
     let result = unsafe { sqlite3ext_overload_function(db, cname.as_ptr(), n_args) };
-    if result != SQLITE_OKAY {
+    if result != SQLITE_OK {
         return Err(Error::new_message("TODO"));
     }
     Ok(())

--- a/src/collation.rs
+++ b/src/collation.rs
@@ -2,13 +2,11 @@
 
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 use crate::{
-    constants::SQLITE_OKAY,
+    constants::{SQLITE_OK, SQLITE_UTF8},
     errors::{Error, ErrorKind, Result},
     ext::{sqlite3, sqlite3ext_collation_v2},
 };
 use std::{ffi::CString, os::raw::c_void};
-
-use sqlite3ext_sys::SQLITE_UTF8;
 
 pub fn define_collation<F>(db: *mut sqlite3, name: &str, x_func: F) -> Result<()>
 where
@@ -43,7 +41,7 @@ where
         )
     };
 
-    if result != SQLITE_OKAY {
+    if result != SQLITE_OK {
         Err(Error::new(ErrorKind::DefineScalarFunction(result)))
     } else {
         Ok(())

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,21 +1,15 @@
-/// rust bindgen for some reason is defining many SQLite constants
-/// as u32, which can't safely be casted into i32. So, here we
-/// hardcode some of those codes to avoid unwrapping
+#[cfg(feature = "static")]
+pub use libsqlite3_sys::{
+    SQLITE_BLOB, SQLITE_CONSTRAINT, SQLITE_DETERMINISTIC, SQLITE_DIRECTONLY, SQLITE_DONE,
+    SQLITE_ERROR, SQLITE_FLOAT, SQLITE_INNOCUOUS, SQLITE_INTEGER, SQLITE_INTERNAL, SQLITE_NULL,
+    SQLITE_OK, SQLITE_OK_LOAD_PERMANENTLY, SQLITE_ROW, SQLITE_SUBTYPE, SQLITE_TEXT, SQLITE_UTF16,
+    SQLITE_UTF16BE, SQLITE_UTF16LE, SQLITE_UTF8,
+};
 
-/// https://www.sqlite.org/rescode.html#ok
-pub const SQLITE_OKAY: i32 = 0;
-
-/// https://www.sqlite.org/rescode.html#internal
-pub const SQLITE_INTERNAL: i32 = 2;
-
-/// https://www.sqlite.org/rescode.html#row
-pub const SQLITE_ROW: i32 = 100;
-
-/// https://www.sqlite.org/rescode.html#done
-pub const SQLITE_DONE: i32 = 101;
-
-/// https://www.sqlite.org/rescode.html#error
-pub const SQLITE_ERROR: i32 = 1;
-
-/// https://www.sqlite.org/rescode.html#constraint
-pub const SQLITE_CONSTRAINT: i32 = 19;
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
+pub use sqlite3ext_sys::{
+    SQLITE_BLOB, SQLITE_CONSTRAINT, SQLITE_DETERMINISTIC, SQLITE_DIRECTONLY, SQLITE_DONE,
+    SQLITE_ERROR, SQLITE_FLOAT, SQLITE_INNOCUOUS, SQLITE_INTEGER, SQLITE_INTERNAL, SQLITE_NULL,
+    SQLITE_OK, SQLITE_OK_LOAD_PERMANENTLY, SQLITE_ROW, SQLITE_SUBTYPE, SQLITE_TEXT, SQLITE_UTF16,
+    SQLITE_UTF16BE, SQLITE_UTF16LE, SQLITE_UTF8,
+};

--- a/src/entrypoints.rs
+++ b/src/entrypoints.rs
@@ -1,13 +1,12 @@
 //! Utilities for working with SQLite's "sqlite3_extension_init"-style
 //! entrypoints.
 use crate::{
+    constants::{SQLITE_OK, SQLITE_OK_LOAD_PERMANENTLY},
     errors::Result,
     ext::{faux_sqlite_extension_init2, sqlite3, sqlite3_api_routines},
 };
 
-use sqlite3ext_sys::SQLITE_OK;
-
-use std::os::raw::{c_char, c_uint};
+use std::os::raw::{c_char, c_int};
 
 /// Low-level wrapper around a typical entrypoint to a SQLite extension.
 /// You shouldn't have to use this directly - the sqlite_entrypoint
@@ -17,7 +16,7 @@ pub fn register_entrypoint<F>(
     _pz_err_msg: *mut *mut c_char,
     p_api: *mut sqlite3_api_routines,
     callback: F,
-) -> c_uint
+) -> c_int
 where
     F: Fn(*mut sqlite3) -> Result<()>,
 {
@@ -26,7 +25,7 @@ where
     }
     match callback(db) {
         Ok(()) => SQLITE_OK,
-        Err(err) => err.code_extended(),
+        Err(err) => err.code(),
     }
 }
 
@@ -38,7 +37,7 @@ pub fn register_entrypoint_load_permanently<F>(
     _pz_err_msg: *mut *mut c_char,
     p_api: *mut sqlite3_api_routines,
     callback: F,
-) -> c_uint
+) -> c_int
 where
     F: Fn(*mut sqlite3) -> Result<()>,
 {
@@ -46,7 +45,7 @@ where
         faux_sqlite_extension_init2(p_api);
     }
     match callback(db) {
-        Ok(()) => 256, // https://www.sqlite.org/rescode.html#ok_load_permanently
-        Err(err) => err.code_extended(),
+        Ok(()) => SQLITE_OK_LOAD_PERMANENTLY,
+        Err(err) => err.code(),
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,5 @@
 //! Custom Error/Result for sqlite-loadable-rs APIs.
-use std::{
-    ffi::NulError,
-    fmt,
-    os::raw::{c_int, c_uint},
-    result,
-};
+use std::{ffi::NulError, fmt, os::raw::c_int, result};
 
 /// A type alias for `Result<T, xxx::Error>`.
 pub type Result<T> = result::Result<T, Error>;
@@ -33,9 +28,6 @@ impl Error {
     }
 
     pub fn code(self) -> c_int {
-        1
-    }
-    pub fn code_extended(self) -> c_uint {
         1
     }
     pub fn result_error_message(self) -> String {

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    constants::SQLITE_OKAY,
+    constants::SQLITE_OK,
     ext::{
         sqlite3ext_bind_int, sqlite3ext_bind_text, sqlite3ext_column_bytes,
         sqlite3ext_column_int64, sqlite3ext_column_text, sqlite3ext_finalize,
@@ -29,7 +29,7 @@ impl Statement {
         let mut stmt: *mut sqlite3_stmt = std::ptr::null_mut();
         let result =
             unsafe { sqlite3ext_prepare_v2(db, s.as_ptr(), n, &mut stmt, std::ptr::null_mut()) };
-        if result != SQLITE_OKAY {
+        if result != SQLITE_OK {
             Err("".into())
         } else {
             Ok(Statement { stmt })
@@ -37,7 +37,7 @@ impl Statement {
     }
     pub fn bind_i32(&mut self, param_idx: i32, value: i32) -> Result<(), Box<dyn Error>> {
         let result = unsafe { sqlite3ext_bind_int(self.stmt, param_idx, value) };
-        if result == SQLITE_OKAY {
+        if result == SQLITE_OK {
             Ok(())
         } else {
             Err("".into())

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -17,19 +17,16 @@ use std::{
 
 #[cfg(feature = "static")]
 pub use libsqlite3_sys::{
-    sqlite3, sqlite3_api_routines, sqlite3_context,
-    sqlite3_index_constraint as sqlite3_index_info_sqlite3_index_constraint,
-    sqlite3_index_constraint_usage as sqlite3_index_info_sqlite3_index_constraint_usage,
-    sqlite3_index_info, sqlite3_index_orderby as sqlite3_index_info_sqlite3_index_orderby,
-    sqlite3_module, sqlite3_stmt, sqlite3_value, sqlite3_vtab, sqlite3_vtab_cursor,
+    sqlite3, sqlite3_api_routines, sqlite3_context, sqlite3_index_constraint,
+    sqlite3_index_constraint_usage, sqlite3_index_info, sqlite3_index_orderby, sqlite3_module,
+    sqlite3_stmt, sqlite3_value, sqlite3_vtab, sqlite3_vtab_cursor,
 };
 
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub use sqlite3ext_sys::{
-    sqlite3, sqlite3_api_routines, sqlite3_context, sqlite3_index_info,
-    sqlite3_index_info_sqlite3_index_constraint, sqlite3_index_info_sqlite3_index_constraint_usage,
-    sqlite3_index_info_sqlite3_index_orderby, sqlite3_module, sqlite3_stmt, sqlite3_value,
-    sqlite3_vtab, sqlite3_vtab_cursor,
+    sqlite3, sqlite3_api_routines, sqlite3_context, sqlite3_index_constraint,
+    sqlite3_index_constraint_usage, sqlite3_index_info, sqlite3_index_orderby, sqlite3_module,
+    sqlite3_stmt, sqlite3_value, sqlite3_vtab, sqlite3_vtab_cursor,
 };
 
 /// If creating a dynmically loadable extension, this MUST be redefined to point
@@ -50,7 +47,7 @@ pub unsafe fn faux_sqlite_extension_init2(api: *mut sqlite3_api_routines) {
     }
 }
 
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 static EXPECT_MESSAGE: &str =
     "sqlite-loadable error: expected method on SQLITE3_API. Please file an issue";
 
@@ -58,7 +55,7 @@ static EXPECT_MESSAGE: &str =
 pub unsafe fn sqlite3ext_value_text(arg1: *mut sqlite3_value) -> *const ::std::os::raw::c_uchar {
     libsqlite3_sys::sqlite3_value_text(arg1)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_value_text(arg1: *mut sqlite3_value) -> *const ::std::os::raw::c_uchar {
     ((*SQLITE3_API).value_text.expect(EXPECT_MESSAGE))(arg1)
 }
@@ -67,7 +64,7 @@ pub unsafe fn sqlite3ext_value_text(arg1: *mut sqlite3_value) -> *const ::std::o
 pub unsafe fn sqlite3ext_value_type(value: *mut sqlite3_value) -> i32 {
     libsqlite3_sys::sqlite3_value_type(value)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_value_type(value: *mut sqlite3_value) -> i32 {
     ((*SQLITE3_API).value_type.expect(EXPECT_MESSAGE))(value)
 }
@@ -75,7 +72,7 @@ pub unsafe fn sqlite3ext_value_type(value: *mut sqlite3_value) -> i32 {
 pub unsafe fn sqlite3ext_value_subtype(value: *mut sqlite3_value) -> u32 {
     libsqlite3_sys::sqlite3_value_subtype(value)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_value_subtype(value: *mut sqlite3_value) -> u32 {
     ((*SQLITE3_API).value_subtype.expect(EXPECT_MESSAGE))(value)
 }
@@ -84,7 +81,7 @@ pub unsafe fn sqlite3ext_value_subtype(value: *mut sqlite3_value) -> u32 {
 pub unsafe fn sqlite3ext_value_bytes(arg1: *mut sqlite3_value) -> i32 {
     libsqlite3_sys::sqlite3_value_bytes(arg1)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_value_bytes(arg1: *mut sqlite3_value) -> i32 {
     ((*SQLITE3_API).value_bytes.expect(EXPECT_MESSAGE))(arg1)
 }
@@ -93,7 +90,7 @@ pub unsafe fn sqlite3ext_value_bytes(arg1: *mut sqlite3_value) -> i32 {
 pub unsafe fn sqlite3ext_value_blob(arg1: *mut sqlite3_value) -> *const c_void {
     libsqlite3_sys::sqlite3_value_blob(arg1)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_value_blob(arg1: *mut sqlite3_value) -> *const c_void {
     ((*SQLITE3_API).value_blob.expect(EXPECT_MESSAGE))(arg1)
 }
@@ -107,7 +104,7 @@ pub unsafe fn sqlite3ext_bind_pointer(
 ) -> i32 {
     libsqlite3_sys::sqlite3_bind_pointer(db, i, p, t, None)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_bind_pointer(
     db: *mut sqlite3_stmt,
     i: i32,
@@ -120,7 +117,7 @@ pub unsafe fn sqlite3ext_bind_pointer(
 pub unsafe fn sqlite3ext_step(stmt: *mut sqlite3_stmt) -> c_int {
     libsqlite3_sys::sqlite3_step(stmt)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_step(stmt: *mut sqlite3_stmt) -> c_int {
     ((*SQLITE3_API).step.expect(EXPECT_MESSAGE))(stmt)
 }
@@ -129,7 +126,7 @@ pub unsafe fn sqlite3ext_step(stmt: *mut sqlite3_stmt) -> c_int {
 pub unsafe fn sqlite3ext_finalize(stmt: *mut sqlite3_stmt) -> c_int {
     libsqlite3_sys::sqlite3_finalize(stmt)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_finalize(stmt: *mut sqlite3_stmt) -> c_int {
     ((*SQLITE3_API).finalize.expect(EXPECT_MESSAGE))(stmt)
 }
@@ -138,7 +135,7 @@ pub unsafe fn sqlite3ext_finalize(stmt: *mut sqlite3_stmt) -> c_int {
 pub unsafe fn sqlite3ext_column_text(stmt: *mut sqlite3_stmt, c: c_int) -> *const c_uchar {
     libsqlite3_sys::sqlite3_column_text(stmt, c)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_column_text(stmt: *mut sqlite3_stmt, c: c_int) -> *const c_uchar {
     ((*SQLITE3_API).column_text.expect(EXPECT_MESSAGE))(stmt, c)
 }
@@ -146,7 +143,7 @@ pub unsafe fn sqlite3ext_column_text(stmt: *mut sqlite3_stmt, c: c_int) -> *cons
 pub unsafe fn sqlite3ext_column_int64(stmt: *mut sqlite3_stmt, c: c_int) -> i64 {
     libsqlite3_sys::sqlite3_column_int64(stmt, c)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_column_int64(stmt: *mut sqlite3_stmt, c: c_int) -> i64 {
     ((*SQLITE3_API).column_int64.expect(EXPECT_MESSAGE))(stmt, c)
 }
@@ -155,7 +152,7 @@ pub unsafe fn sqlite3ext_column_int64(stmt: *mut sqlite3_stmt, c: c_int) -> i64 
 pub unsafe fn sqlite3ext_column_bytes(stmt: *mut sqlite3_stmt, c: c_int) -> i32 {
     libsqlite3_sys::sqlite3_column_bytes(stmt, c)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_column_bytes(stmt: *mut sqlite3_stmt, c: c_int) -> i32 {
     ((*SQLITE3_API).column_bytes.expect(EXPECT_MESSAGE))(stmt, c)
 }
@@ -164,7 +161,7 @@ pub unsafe fn sqlite3ext_column_bytes(stmt: *mut sqlite3_stmt, c: c_int) -> i32 
 pub unsafe fn sqlite3ext_column_value(stmt: *mut sqlite3_stmt, c: c_int) -> *mut sqlite3_value {
     libsqlite3_sys::sqlite3_column_value(stmt, c)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_column_value(stmt: *mut sqlite3_stmt, c: c_int) -> *mut sqlite3_value {
     ((*SQLITE3_API).column_value.expect(EXPECT_MESSAGE))(stmt, c)
 }
@@ -179,7 +176,7 @@ pub unsafe fn sqlite3ext_bind_text(
 ) -> i32 {
     libsqlite3_sys::sqlite3_bind_text(stmt, c, s, n, destructor)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_bind_text(
     stmt: *mut sqlite3_stmt,
     c: c_int,
@@ -193,7 +190,7 @@ pub unsafe fn sqlite3ext_bind_text(
 pub unsafe fn sqlite3ext_bind_int(stmt: *mut sqlite3_stmt, c: c_int, v: c_int) -> i32 {
     libsqlite3_sys::sqlite3_bind_int(stmt, c, v)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_bind_int(stmt: *mut sqlite3_stmt, c: c_int, v: c_int) -> i32 {
     ((*SQLITE3_API).bind_int.expect(EXPECT_MESSAGE))(stmt, c, v)
 }
@@ -201,7 +198,7 @@ pub unsafe fn sqlite3ext_bind_int(stmt: *mut sqlite3_stmt, c: c_int, v: c_int) -
 pub unsafe fn sqlite3ext_bind_int64(stmt: *mut sqlite3_stmt, c: c_int, v: i64) -> i32 {
     libsqlite3_sys::sqlite3_bind_int64(stmt, c, v)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_bind_int64(stmt: *mut sqlite3_stmt, c: c_int, v: i64) -> i32 {
     ((*SQLITE3_API).bind_int64.expect(EXPECT_MESSAGE))(stmt, c, v)
 }
@@ -216,7 +213,7 @@ pub unsafe fn sqlite3ext_prepare_v2(
 ) -> i32 {
     libsqlite3_sys::sqlite3_prepare_v2(db, sql, n, stmt, leftover)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_prepare_v2(
     db: *mut sqlite3,
     sql: *const c_char,
@@ -231,7 +228,7 @@ pub unsafe fn sqlite3ext_prepare_v2(
 pub unsafe fn sqlite3ext_value_int(arg1: *mut sqlite3_value) -> i32 {
     libsqlite3_sys::sqlite3_value_int(arg1)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_value_int(arg1: *mut sqlite3_value) -> i32 {
     ((*SQLITE3_API).value_int.expect(EXPECT_MESSAGE))(arg1)
 }
@@ -240,7 +237,7 @@ pub unsafe fn sqlite3ext_value_int(arg1: *mut sqlite3_value) -> i32 {
 pub unsafe fn sqlite3ext_value_int64(arg1: *mut sqlite3_value) -> i64 {
     libsqlite3_sys::sqlite3_value_int64(arg1)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_value_int64(arg1: *mut sqlite3_value) -> i64 {
     ((*SQLITE3_API).value_int64.expect(EXPECT_MESSAGE))(arg1)
 }
@@ -249,7 +246,7 @@ pub unsafe fn sqlite3ext_value_int64(arg1: *mut sqlite3_value) -> i64 {
 pub unsafe fn sqlite3ext_value_double(arg1: *mut sqlite3_value) -> f64 {
     libsqlite3_sys::sqlite3_value_double(arg1)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_value_double(arg1: *mut sqlite3_value) -> f64 {
     ((*SQLITE3_API).value_double.expect(EXPECT_MESSAGE))(arg1)
 }
@@ -258,7 +255,7 @@ pub unsafe fn sqlite3ext_value_double(arg1: *mut sqlite3_value) -> f64 {
 pub unsafe fn sqlite3ext_value_pointer(arg1: *mut sqlite3_value, p: *mut c_char) -> *mut c_void {
     libsqlite3_sys::sqlite3_value_pointer(arg1, p)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_value_pointer(arg1: *mut sqlite3_value, p: *mut c_char) -> *mut c_void {
     ((*SQLITE3_API).value_pointer.expect(EXPECT_MESSAGE))(arg1, p)
 }
@@ -267,7 +264,7 @@ pub unsafe fn sqlite3ext_value_pointer(arg1: *mut sqlite3_value, p: *mut c_char)
 pub unsafe fn sqlite3ext_result_int(context: *mut sqlite3_context, v: c_int) {
     libsqlite3_sys::sqlite3_result_int(context, v)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_result_int(context: *mut sqlite3_context, v: c_int) {
     if false {
     } else {
@@ -286,7 +283,7 @@ pub unsafe fn sqlite3ext_result_int(context: *mut sqlite3_context, v: c_int) {
 pub unsafe fn sqlite3ext_result_blob(context: *mut sqlite3_context, p: *const c_void, n: i32) {
     libsqlite3_sys::sqlite3_result_blob(context, p, n, Some(mem::transmute(-1_isize)));
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_result_blob(context: *mut sqlite3_context, p: *const c_void, n: i32) {
     ((*SQLITE3_API).result_blob.expect(EXPECT_MESSAGE))(
         context,
@@ -299,7 +296,7 @@ pub unsafe fn sqlite3ext_result_blob(context: *mut sqlite3_context, p: *const c_
 pub unsafe fn sqlite3ext_result_int64(context: *mut sqlite3_context, v: i64) {
     libsqlite3_sys::sqlite3_result_int64(context, v);
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_result_int64(context: *mut sqlite3_context, v: i64) {
     ((*SQLITE3_API).result_int64.expect(EXPECT_MESSAGE))(context, v);
 }
@@ -308,7 +305,7 @@ pub unsafe fn sqlite3ext_result_int64(context: *mut sqlite3_context, v: i64) {
 pub unsafe fn sqlite3ext_result_double(context: *mut sqlite3_context, f: f64) {
     libsqlite3_sys::sqlite3_result_double(context, f)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_result_double(context: *mut sqlite3_context, f: f64) {
     ((*SQLITE3_API).result_double.expect(EXPECT_MESSAGE))(context, f);
 }
@@ -317,7 +314,7 @@ pub unsafe fn sqlite3ext_result_double(context: *mut sqlite3_context, f: f64) {
 pub unsafe fn sqlite3ext_result_null(context: *mut sqlite3_context) {
     libsqlite3_sys::sqlite3_result_null(context);
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_result_null(context: *mut sqlite3_context) {
     ((*SQLITE3_API).result_null.expect(EXPECT_MESSAGE))(context);
 }
@@ -330,7 +327,7 @@ pub unsafe fn sqlite3ext_result_pointer(
 ) {
     libsqlite3_sys::sqlite3_result_pointer(context, pointer, name, destructor)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_result_pointer(
     context: *mut sqlite3_context,
     pointer: *mut c_void,
@@ -344,7 +341,7 @@ pub unsafe fn sqlite3ext_result_pointer(
 pub unsafe fn sqlite3ext_result_error(context: *mut sqlite3_context, s: *const c_char, n: i32) {
     libsqlite3_sys::sqlite3_result_error(context, s, n);
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_result_error(context: *mut sqlite3_context, s: *const c_char, n: i32) {
     ((*SQLITE3_API).result_error.expect(EXPECT_MESSAGE))(context, s, n);
 }
@@ -353,7 +350,7 @@ pub unsafe fn sqlite3ext_result_error(context: *mut sqlite3_context, s: *const c
 pub unsafe fn sqlite3ext_result_error_code(context: *mut sqlite3_context, code: i32) {
     libsqlite3_sys::sqlite3_result_error_code(context, code);
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_result_error_code(context: *mut sqlite3_context, code: i32) {
     ((*SQLITE3_API).result_error_code.expect(EXPECT_MESSAGE))(context, code);
 }
@@ -366,7 +363,7 @@ pub unsafe fn sqlite3ext_result_text(
 ) {
     libsqlite3_sys::sqlite3_result_text(context, s, n, d);
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_result_text(
     context: *mut sqlite3_context,
     s: *const c_char,
@@ -380,7 +377,7 @@ pub unsafe fn sqlite3ext_result_text(
 pub unsafe fn sqlite3ext_result_subtype(context: *mut sqlite3_context, subtype: u32) {
     libsqlite3_sys::sqlite3_result_subtype(context, subtype)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_result_subtype(context: *mut sqlite3_context, subtype: u32) {
     ((*SQLITE3_API).result_subtype.expect(EXPECT_MESSAGE))(context, subtype);
 }
@@ -394,7 +391,7 @@ pub unsafe fn sqlite3ext_set_auxdata(
 ) {
     libsqlite3_sys::sqlite3_set_auxdata(context, n, p, d);
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_set_auxdata(
     context: *mut sqlite3_context,
     n: c_int,
@@ -408,7 +405,7 @@ pub unsafe fn sqlite3ext_set_auxdata(
 pub unsafe fn sqlite3ext_get_auxdata(context: *mut sqlite3_context, n: c_int) -> *mut c_void {
     libsqlite3_sys::sqlite3_get_auxdata(context, n)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_get_auxdata(context: *mut sqlite3_context, n: c_int) -> *mut c_void {
     ((*SQLITE3_API).get_auxdata.expect(EXPECT_MESSAGE))(context, n)
 }
@@ -429,7 +426,7 @@ pub unsafe fn sqlite3ext_create_function_v2(
         db, s, argc, text_rep, p_app, x_func, x_step, x_final, destroy,
     )
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_create_function_v2(
     db: *mut sqlite3,
     s: *const c_char,
@@ -464,7 +461,7 @@ pub unsafe fn sqlite3ext_collation_v2(
 ) -> c_int {
     libsqlite3_sys::sqlite3_create_collation_v2(db, s, text_rep, p_app, x_compare, destroy)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_collation_v2(
     db: *mut sqlite3,
     s: *const c_char,
@@ -496,7 +493,7 @@ pub unsafe fn sqlite3ext_create_module_v2(
 ) -> i32 {
     libsqlite3_sys::sqlite3_create_module_v2(db, s, module, p_app, destroy)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_create_module_v2(
     db: *mut sqlite3,
     s: *const c_char,
@@ -511,7 +508,7 @@ pub unsafe fn sqlite3ext_create_module_v2(
 pub unsafe fn sqlite3ext_vtab_distinct(index_info: *mut sqlite3_index_info) -> i32 {
     libsqlite3_sys::sqlite3_vtab_distinct(index_info)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_vtab_distinct(index_info: *mut sqlite3_index_info) -> i32 {
     ((*SQLITE3_API).vtab_distinct.expect(EXPECT_MESSAGE))(index_info)
 }
@@ -524,7 +521,7 @@ pub unsafe fn sqlite3ext_vtab_in(
 ) -> i32 {
     libsqlite3_sys::sqlite3_vtab_in(index_info, constraint_idx, handle)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_vtab_in(
     index_info: *mut sqlite3_index_info,
     constraint_idx: i32,
@@ -540,7 +537,7 @@ pub unsafe fn sqlite3ext_vtab_in_first(
 ) -> i32 {
     libsqlite3_sys::sqlite3_vtab_in_first(value_list, value_out)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_vtab_in_first(
     value_list: *mut sqlite3_value,
     value_out: *mut *mut sqlite3_value,
@@ -555,7 +552,7 @@ pub unsafe fn sqlite3ext_vtab_in_next(
 ) -> i32 {
     libsqlite3_sys::sqlite3_vtab_in_next(value_list, value_out)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_vtab_in_next(
     value_list: *mut sqlite3_value,
     value_out: *mut *mut sqlite3_value,
@@ -567,9 +564,9 @@ pub unsafe fn sqlite3ext_vtab_in_next(
 pub unsafe fn sqlite3ext_declare_vtab(db: *mut sqlite3, s: *const c_char) -> i32 {
     libsqlite3_sys::sqlite3_declare_vtab(db, s)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_declare_vtab(db: *mut sqlite3, s: *const c_char) -> i32 {
-    #[cfg(not(feature = "static"))]
+    #[cfg(all(not(feature = "static"), feature = "dynamic"))]
     ((*SQLITE3_API).declare_vtab.expect(EXPECT_MESSAGE))(db, s)
 }
 
@@ -577,7 +574,7 @@ pub unsafe fn sqlite3ext_declare_vtab(db: *mut sqlite3, s: *const c_char) -> i32
 pub unsafe fn sqlite3ext_overload_function(db: *mut sqlite3, s: *const c_char, n: i32) -> i32 {
     libsqlite3_sys::sqlite3_overload_function(db, s, n)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_overload_function(db: *mut sqlite3, s: *const c_char, n: i32) -> i32 {
     ((*SQLITE3_API).overload_function.expect(EXPECT_MESSAGE))(db, s, n)
 }
@@ -586,7 +583,7 @@ pub unsafe fn sqlite3ext_overload_function(db: *mut sqlite3, s: *const c_char, n
 pub unsafe fn sqlite3ext_context_db_handle(context: *mut sqlite3_context) -> *mut sqlite3 {
     libsqlite3_sys::sqlite3_context_db_handle(context)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_context_db_handle(context: *mut sqlite3_context) -> *mut sqlite3 {
     ((*SQLITE3_API).context_db_handle.expect(EXPECT_MESSAGE))(context)
 }
@@ -595,7 +592,7 @@ pub unsafe fn sqlite3ext_context_db_handle(context: *mut sqlite3_context) -> *mu
 pub unsafe fn sqlite3ext_user_data(context: *mut sqlite3_context) -> *mut c_void {
     libsqlite3_sys::sqlite3_user_data(context)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_user_data(context: *mut sqlite3_context) -> *mut c_void {
     ((*SQLITE3_API).user_data.expect(EXPECT_MESSAGE))(context)
 }
@@ -603,7 +600,7 @@ pub unsafe fn sqlite3ext_user_data(context: *mut sqlite3_context) -> *mut c_void
 pub unsafe fn sqlite3ext_mprintf(s: *const c_char) -> *mut c_char {
     libsqlite3_sys::sqlite3_mprintf(s)
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_mprintf(s: *const c_char) -> *mut c_char {
     ((*SQLITE3_API).mprintf.expect(EXPECT_MESSAGE))(s)
 }
@@ -612,7 +609,7 @@ pub unsafe fn sqlite3ext_mprintf(s: *const c_char) -> *mut c_char {
 pub unsafe fn sqlite3ext_auto_extension(f: unsafe extern "C" fn()) -> i32 {
     libsqlite3_sys::sqlite3_auto_extension(Some(f))
 }
-#[cfg(not(feature = "static"))]
+#[cfg(all(not(feature = "static"), feature = "dynamic"))]
 pub unsafe fn sqlite3ext_auto_extension(f: unsafe extern "C" fn()) -> i32 {
     ((*SQLITE3_API).auto_extension.expect(EXPECT_MESSAGE))(Some(f))
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -12,6 +12,6 @@ pub use crate::ext::{
 pub use sqlite_loadable_macros::sqlite_entrypoint;
 pub use sqlite_loadable_macros::sqlite_entrypoint_permanent;
 
-pub use std::os::raw::{c_char, c_uint};
+pub use std::os::raw::{c_char, c_int};
 
 pub use crate::FunctionFlags;

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -9,7 +9,10 @@ use std::{
 
 use crate::{
     api,
-    constants::{SQLITE_INTERNAL, SQLITE_OKAY},
+    constants::{
+        SQLITE_DETERMINISTIC, SQLITE_DIRECTONLY, SQLITE_INNOCUOUS, SQLITE_INTERNAL, SQLITE_OK,
+        SQLITE_SUBTYPE, SQLITE_UTF16, SQLITE_UTF16BE, SQLITE_UTF16LE, SQLITE_UTF8,
+    },
     errors::{Error, ErrorKind, Result},
     ext::{
         sqlite3, sqlite3_context, sqlite3_value, sqlite3ext_create_function_v2,
@@ -18,11 +21,6 @@ use crate::{
 };
 
 use bitflags::bitflags;
-
-use sqlite3ext_sys::{
-    SQLITE_DETERMINISTIC, SQLITE_DIRECTONLY, SQLITE_INNOCUOUS, SQLITE_SUBTYPE, SQLITE_UTF16,
-    SQLITE_UTF16BE, SQLITE_UTF16LE, SQLITE_UTF8,
-};
 
 bitflags! {
     /// Represents the possible flag values that can be passed into sqlite3_create_function_v2
@@ -71,7 +69,7 @@ fn create_function_v2(
         )
     };
 
-    if result != SQLITE_OKAY {
+    if result != SQLITE_OK {
         Err(Error::new(ErrorKind::DefineScalarFunction(result)))
     } else {
         Ok(())


### PR DESCRIPTION
- Upgraded bindgen
- Fixed your u32 vs i32 issue
- Made the sys crate optional (enabled by default)

This is technically a breaking change since we changed the return value of some functions.