### PR TITLE
Wrap `no_mangle` in `unsafe`

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -93,7 +93,7 @@ make sqlite3_wasm_extra_init.c=../../../../target/wasm32-unknown-emscripten/debu
 ```
 
 ```rs
-#[no_mangle]
+#[unsafe(no_mangle)]
 /// in hello.rs
 
 

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -28,7 +28,7 @@ pub fn sqlite3_hello_init(db: *mut sqlite3) -> Result<()> {
 }
 
 #[cfg(target_os = "emscripten")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn sqlite3_wasm_extra_init(_unused: *const std::ffi::c_char) -> std::ffi::c_int {
     use sqlite_loadable::SQLITE_OKAY;
     unsafe {

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -28,7 +28,7 @@ pub fn sqlite3_stress_init(db: *mut sqlite3) -> Result<()> {
 }
 
 #[cfg(target_os = "emscripten")]
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn sqlite3_wasm_extra_init(_unused: *const std::ffi::c_char) -> std::ffi::c_int {
     use sqlite_loadable::SQLITE_OKAY;
     unsafe {

--- a/sqlite-loadable-macros/src/lib.rs
+++ b/sqlite-loadable-macros/src/lib.rs
@@ -28,7 +28,7 @@ pub fn sqlite_entrypoint(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 ///
                 /// Should only be called by underlying SQLite C APIs,
                 /// like sqlite3_auto_extension and sqlite3_cancel_auto_extension.
-                #[no_mangle]
+                #[unsafe(no_mangle)]
                 pub unsafe extern "C" fn #c_entrypoint(
                     db: *mut sqlite3,
                     pz_err_msg: *mut *mut c_char,
@@ -68,7 +68,7 @@ pub fn sqlite_entrypoint_permanent(_attr: TokenStream, item: TokenStream) -> Tok
                 ///
                 /// Should only be called by underlying SQLite C APIs,
                 /// like sqlite3_auto_extension and sqlite3_cancel_auto_extension.
-                #[no_mangle]
+                #[unsafe(no_mangle)]
                 pub unsafe extern "C" fn #c_entrypoint(
                     db: *mut sqlite3,
                     pz_err_msg: *mut *mut c_char,


### PR DESCRIPTION
As of the Rust 2024 edition. The `no_mangle` attribute must be wrapped in `unsafe`. This PR changes the macro in this crate to emit `unsafe(no_mangle)` instead, so that this crate now compiles in the 2024 edition.

I hope that this is backwards compatible with older versions. Unfortuantly, there is no `cfg!(edition >= 2024)` to branch on.