### PR TITLE
vtab_argparse: split config options on the first '=' and trim keys

### DIFF
--- a/src/vtab_argparse.rs
+++ b/src/vtab_argparse.rs
@@ -151,8 +151,9 @@ pub fn parse_argument(argument: &str) -> std::result::Result<Argument, String> {
 /// TODO renamed "parameter" to "named argument"
 fn arg_is_config_option(arg: &str) -> Result<Option<ConfigOption>, String> {
     let mut split = arg.split('=');
+    // `key = value` with spaces around `=` is common in hand-written SQL.
     let key = match split.next() {
-        Some(k) => k,
+        Some(k) => k.trim(),
         None => return Ok(None),
     };
     let value = match split.next() {

--- a/src/vtab_argparse.rs
+++ b/src/vtab_argparse.rs
@@ -150,16 +150,13 @@ pub fn parse_argument(argument: &str) -> std::result::Result<Argument, String> {
 
 /// TODO renamed "parameter" to "named argument"
 fn arg_is_config_option(arg: &str) -> Result<Option<ConfigOption>, String> {
-    let mut split = arg.split('=');
+    // Split on the first `=` only: values such as Hive-partitioned URLs
+    // (`source='s3://b/theme=places/type=place/*'`) contain their own.
     // `key = value` with spaces around `=` is common in hand-written SQL.
-    let key = match split.next() {
-        Some(k) => k.trim(),
-        None => return Ok(None),
+    let Some((key, value)) = arg.split_once('=') else {
+        return Ok(None);
     };
-    let value = match split.next() {
-        Some(k) => k,
-        None => return Ok(None),
-    };
+    let key = key.trim();
     Ok(Some(ConfigOption {
         key: key.to_owned(),
         value: parse_config_option_value(key.to_string(), value)?,
@@ -240,6 +237,21 @@ mod tests {
             Ok(Argument::Config(ConfigOption {
                 key: "option".to_owned(),
                 value: ConfigOptionValue::Bareword("bareword".to_owned())
+            }))
+        );
+        // values keep their own '=' (Hive-style partitioned paths)
+        assert_eq!(
+            parse_argument("source='s3://b/theme=places/type=place/*'"),
+            Ok(Argument::Config(ConfigOption {
+                key: "source".to_owned(),
+                value: ConfigOptionValue::Quoted("s3://b/theme=places/type=place/*".to_owned())
+            }))
+        );
+        assert_eq!(
+            parse_argument("source = s3://b/a=1/x.parquet"),
+            Ok(Argument::Config(ConfigOption {
+                key: "source".to_owned(),
+                value: ConfigOptionValue::Bareword("s3://b/a=1/x.parquet".to_owned())
             }))
         );
     }


### PR DESCRIPTION
<!-- Human summary goes here before review -->

<details>
<summary>🤖 Claude-generated PR description</summary>

Two small fixes to `vtab_argparse::parse_argument` for `key=value` options in `CREATE VIRTUAL TABLE ... USING mod(...)` arguments:

- **Split on the first `=` only.** Values that contain their own `=` (Hive-partitioned paths like `source='s3://b/theme=places/type=place/*'`) used to be truncated at the second `=`.
- **Trim whitespace around the key**, so hand-written `key = 'value'` parses the same as `key='value'`.

Unit tests cover both cases. Independent of the other release PRs; based on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeJ1M1czEyy2mnbLFJ8Hon

</details>
