### PR TITLE
exec/api/table: surface SQLite's errmsg, raw stmt/value accessors, result_pointer_with_destructor

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -375,6 +375,26 @@ pub fn result_pointer<T>(context: *mut sqlite3_context, name: &[u8], object: T) 
     };
 }
 
+/// Like [`result_pointer`], but with a caller-supplied destructor that
+/// receives the raw `Box<T>` pointer (the caller must `Box::from_raw` it).
+pub fn result_pointer_with_destructor<T>(
+    context: *mut sqlite3_context,
+    name: &[u8],
+    object: T,
+    destructor: Option<unsafe extern "C" fn(*mut c_void)>,
+) {
+    let b = Box::new(object);
+    let pointer = Box::into_raw(b).cast::<c_void>();
+    unsafe {
+        sqlite3ext_result_pointer(
+            context,
+            pointer,
+            name.as_ptr().cast::<c_char>().cast_mut(),
+            destructor,
+        )
+    };
+}
+
 // TODO maybe take in a Box<T>?
 /// [`sqlite3_set_auxdata`](https://www.sqlite.org/c3ref/get_auxdata.html)
 pub fn auxdata_set(

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -1,4 +1,4 @@
-use sqlite3ext_sys::{sqlite3, sqlite3_stmt};
+use crate::ext::{sqlite3, sqlite3_stmt, sqlite3_value};
 use std::{
     error::Error,
     ffi::{c_char, c_void, CString},
@@ -8,8 +8,8 @@ use crate::{
     constants::SQLITE_OKAY,
     ext::{
         sqlite3ext_bind_int, sqlite3ext_bind_text, sqlite3ext_column_bytes,
-        sqlite3ext_column_int64, sqlite3ext_column_text, sqlite3ext_finalize,
-        sqlite3ext_prepare_v2, sqlite3ext_step,
+        sqlite3ext_column_int64, sqlite3ext_column_text, sqlite3ext_column_value,
+        sqlite3ext_errmsg, sqlite3ext_finalize, sqlite3ext_prepare_v2, sqlite3ext_step,
     },
 };
 
@@ -30,10 +30,15 @@ impl Statement {
         let result =
             unsafe { sqlite3ext_prepare_v2(db, s.as_ptr(), n, &mut stmt, std::ptr::null_mut()) };
         if result != SQLITE_OKAY {
-            Err("".into())
+            Err(unsafe { errmsg(db) }.into())
         } else {
             Ok(Statement { stmt })
         }
+    }
+    /// Raw `sqlite3_stmt` pointer, for callers that need column accessors
+    /// not wrapped here.
+    pub fn as_ptr(&self) -> *mut sqlite3_stmt {
+        self.stmt
     }
     pub fn bind_i32(&mut self, param_idx: i32, value: i32) -> Result<(), Box<dyn Error>> {
         let result = unsafe { sqlite3ext_bind_int(self.stmt, param_idx, value) };
@@ -98,6 +103,20 @@ impl Row {
     pub fn get<T: Value>(&self, idx: i32) -> Result<T, ()> {
         Value::value_result(self.stmt, idx)
     }
+    /// The raw [`sqlite3_value`](https://www.sqlite.org/c3ref/column_blob.html)
+    /// of column `idx`. Only valid until the next `step`/`reset`/`finalize`.
+    pub fn value(&self, idx: i32) -> *mut sqlite3_value {
+        unsafe { sqlite3ext_column_value(self.stmt, idx) }
+    }
+}
+
+/// The current error message of `db`, as an owned String.
+pub(crate) unsafe fn errmsg(db: *mut sqlite3) -> String {
+    let p = sqlite3ext_errmsg(db);
+    if p.is_null() {
+        return String::new();
+    }
+    std::ffi::CStr::from_ptr(p).to_string_lossy().into_owned()
 }
 
 pub trait Value: Sized {

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -117,6 +117,14 @@ pub unsafe fn sqlite3ext_bind_pointer(
     ((*SQLITE3_API).bind_pointer.expect(EXPECT_MESSAGE))(db, i, p, t, None)
 }
 #[cfg(feature = "static")]
+pub unsafe fn sqlite3ext_errmsg(db: *mut sqlite3) -> *const c_char {
+    libsqlite3_sys::sqlite3_errmsg(db)
+}
+#[cfg(not(feature = "static"))]
+pub unsafe fn sqlite3ext_errmsg(db: *mut sqlite3) -> *const c_char {
+    ((*SQLITE3_API).errmsg.expect(EXPECT_MESSAGE))(db)
+}
+#[cfg(feature = "static")]
 pub unsafe fn sqlite3ext_step(stmt: *mut sqlite3_stmt) -> c_int {
     libsqlite3_sys::sqlite3_step(stmt)
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -17,7 +17,7 @@ use crate::ext::{
     sqlite3, sqlite3_context, sqlite3_index_info, sqlite3_index_info_sqlite3_index_constraint,
     sqlite3_index_info_sqlite3_index_constraint_usage, sqlite3_index_info_sqlite3_index_orderby,
     sqlite3_module, sqlite3_value, sqlite3_vtab, sqlite3_vtab_cursor, sqlite3ext_create_module_v2,
-    sqlite3ext_declare_vtab, sqlite3ext_vtab_distinct, sqlite3ext_vtab_in,
+    sqlite3ext_declare_vtab, sqlite3ext_errmsg, sqlite3ext_vtab_distinct, sqlite3ext_vtab_in,
     sqlite3ext_vtab_in_first, sqlite3ext_vtab_in_next,
 };
 use serde::{Deserialize, Serialize};
@@ -886,6 +886,12 @@ where
                     *pp_vtab = boxed_vtab.cast::<sqlite3_vtab>();
                     SQLITE_OKAY
                 } else {
+                    // Surface SQLite's own reason (e.g. "duplicate column name: x")
+                    // instead of the generic "vtable constructor failed".
+                    let reason = std::ffi::CStr::from_ptr(sqlite3ext_errmsg(db)).to_string_lossy();
+                    if let Ok(err) = mprintf(&format!("invalid virtual table schema: {}", reason)) {
+                        *err_msg = err;
+                    }
                     rc
                 }
             }
@@ -929,6 +935,12 @@ where
                     *pp_vtab = boxed_vtab.cast::<sqlite3_vtab>();
                     SQLITE_OKAY
                 } else {
+                    // Surface SQLite's own reason (e.g. "duplicate column name: x")
+                    // instead of the generic "vtable constructor failed".
+                    let reason = std::ffi::CStr::from_ptr(sqlite3ext_errmsg(db)).to_string_lossy();
+                    if let Ok(err) = mprintf(&format!("invalid virtual table schema: {}", reason)) {
+                        *err_msg = err;
+                    }
                     rc
                 }
             }


### PR DESCRIPTION
<!-- Human summary goes here before review -->

<details>
<summary>🤖 Claude-generated PR description</summary>

Small plumbing changes that the panic-guard, scan_config and source PRs all build on, split out so they can be reviewed alone:

- **`ext::sqlite3ext_errmsg`** (dylib + `static` variants).
- **`exec::Statement::prepare`** returns SQLite's actual error message instead of an empty string.
- **`table`**: when `sqlite3_declare_vtab` rejects a schema, `xCreate`/`xConnect` now report `invalid virtual table schema: <SQLite message>` (e.g. `duplicate column name: x`) instead of the generic "vtable constructor failed".
- **`exec::Statement::as_ptr`** and **`exec::Row::value`** expose the raw `sqlite3_stmt` / `sqlite3_value` for callers that need column accessors not wrapped here.
- **`api::result_pointer_with_destructor`**: `result_pointer` with a caller-supplied destructor (the source API uses it to refcount its vtable).

No behaviour change for existing callers beyond better error text. Based on `main`; `pr/panic-guards`, `pr/scan-config` and `pr/source-api` are stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeJ1M1czEyy2mnbLFJ8Hon

</details>
