### PR TITLE
Panic guards in scalar and virtual-table shims

### DIFF
--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -115,12 +115,17 @@ where
         let boxed_function: *mut F = sqlite3ext_user_data(context).cast::<F>();
         // .collect slows things waaaay down, so stick with slice for now
         let args = slice::from_raw_parts(argv, argc as usize);
-        match (*boxed_function)(context, args) {
-            Ok(()) => (),
-            Err(e) => {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            (*boxed_function)(context, args)
+        })) {
+            Ok(Ok(())) => (),
+            Ok(Err(e)) => {
                 if api::result_error(context, &e.result_error_message()).is_err() {
                     api::result_error_code(context, SQLITE_INTERNAL);
                 }
+            }
+            Err(e) => {
+                let _ = api::result_error(context, &crate::table::panic_message(&*e));
             }
         }
     }
@@ -168,16 +173,22 @@ where
         let aux = (*x).1;
         // .collect slows things waaaay down, so stick with slice for now
         let args = slice::from_raw_parts(argv, argc as usize);
-        let b = Box::from_raw(aux);
-        match (*boxed_function)(context, args, &*b) {
-            Ok(()) => (),
-            Err(e) => {
+        // `aux` is owned by the registration (freed by the destructor passed
+        // to create_function_v2, if any); only borrow it here.
+        let aux: &T = &*aux;
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            (*boxed_function)(context, args, aux)
+        })) {
+            Ok(Ok(())) => (),
+            Ok(Err(e)) => {
                 if api::result_error(context, &e.result_error_message()).is_err() {
                     api::result_error_code(context, SQLITE_INTERNAL);
                 }
             }
+            Err(e) => {
+                let _ = api::result_error(context, &crate::table::panic_message(&*e));
+            }
         }
-        Box::into_raw(b);
     }
     create_function_v2(
         db,
@@ -230,12 +241,17 @@ where
     {
         let boxed_function: *mut F = sqlite3ext_user_data(context).cast::<F>();
         let args = slice::from_raw_parts(argv, argc as usize);
-        match (*boxed_function)(context, args) {
-            Ok(()) => (),
-            Err(e) => {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            (*boxed_function)(context, args)
+        })) {
+            Ok(Ok(())) => (),
+            Ok(Err(e)) => {
                 if api::result_error(context, &e.result_error_message()).is_err() {
                     api::result_error_code(context, SQLITE_INTERNAL);
                 }
+            }
+            Err(e) => {
+                let _ = api::result_error(context, &crate::table::panic_message(&*e));
             }
         }
     }
@@ -269,16 +285,22 @@ where
         let aux = (*x).1;
 
         let args = slice::from_raw_parts(argv, argc as usize);
-        let b = Box::from_raw(aux);
-        match (*boxed_function)(context, args, &*b) {
-            Ok(()) => (),
-            Err(e) => {
+        // `aux` is owned by the registration (freed by the destructor passed
+        // to create_function_v2, if any); only borrow it here.
+        let aux: &T = &*aux;
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            (*boxed_function)(context, args, aux)
+        })) {
+            Ok(Ok(())) => (),
+            Ok(Err(e)) => {
                 if api::result_error(context, &e.result_error_message()).is_err() {
                     api::result_error_code(context, SQLITE_INTERNAL);
                 }
             }
+            Err(e) => {
+                let _ = api::result_error(context, &crate::table::panic_message(&*e));
+            }
         }
-        Box::into_raw(b);
     }
 
     (x_func_wrapper::<F, T>, app_pointer.cast())

--- a/src/table.rs
+++ b/src/table.rs
@@ -859,6 +859,49 @@ fn process_create_args(
         arguments: arguments.to_vec(),
     })
 }
+
+/// Text for a caught panic payload.
+pub(crate) fn panic_message(e: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = e.downcast_ref::<&str>() {
+        format!("panic: {}", s)
+    } else if let Some(s) = e.downcast_ref::<String>() {
+        format!("panic: {}", s)
+    } else {
+        "panic (non-string payload)".to_owned()
+    }
+}
+
+/// Runs a virtual-table callback, turning a Rust panic into `SQLITE_ERROR`
+/// with a message on the vtab instead of unwinding across the C boundary
+/// (which aborts the host process).
+unsafe fn guard_vtab(vtab: *mut sqlite3_vtab, f: impl FnOnce() -> c_int) -> c_int {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(rc) => rc,
+        Err(e) => {
+            if !vtab.is_null() {
+                if let Ok(msg) = mprintf(&panic_message(&*e)) {
+                    (*vtab).zErrMsg = msg;
+                }
+            }
+            SQLITE_ERROR
+        }
+    }
+}
+
+/// Like [`guard_vtab`] for xCreate/xConnect, which report through `*err_msg`.
+unsafe fn guard_errmsg(err_msg: *mut *mut c_char, f: impl FnOnce() -> c_int) -> c_int {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(rc) => rc,
+        Err(e) => {
+            if !err_msg.is_null() {
+                if let Ok(msg) = mprintf(&panic_message(&*e)) {
+                    *err_msg = msg;
+                }
+            }
+            SQLITE_ERROR
+        }
+    }
+}
 /// <https://www.sqlite.org/vtab.html#the_xcreate_method>
 // TODO set error message properly
 unsafe extern "C" fn rust_create<'vtab, T>(
@@ -872,6 +915,7 @@ unsafe extern "C" fn rust_create<'vtab, T>(
 where
     T: VTab<'vtab>,
 {
+    guard_errmsg(err_msg, || {
     let aux = aux.cast::<T::Aux>();
     let args = match process_create_args(argc, argv) {
         Ok(args) => args,
@@ -906,6 +950,7 @@ where
             err.code()
         }
     }
+})
 }
 
 /// <https://www.sqlite.org/vtab.html#the_xconnect_method>
@@ -921,6 +966,7 @@ unsafe extern "C" fn rust_connect<'vtab, T>(
 where
     T: VTab<'vtab>,
 {
+    guard_errmsg(err_msg, || {
     let aux = aux.cast::<T::Aux>();
     let args = match process_create_args(argc, argv) {
         Ok(args) => args,
@@ -955,6 +1001,7 @@ where
             err.code()
         }
     }
+})
 }
 
 /// <https://www.sqlite.org/vtab.html#the_xbestindex_method>
@@ -966,6 +1013,7 @@ unsafe extern "C" fn rust_best_index<'vtab, T>(
 where
     T: VTab<'vtab>,
 {
+    guard_vtab(vtab, || {
     let vt = vtab.cast::<T>();
     match (*vt).best_index(IndexInfo { index_info }) {
         Ok(_) => SQLITE_OKAY,
@@ -974,6 +1022,7 @@ where
             BestIndexError::Error => SQLITE_ERROR,
         },
     }
+})
 }
 
 /// <https://www.sqlite.org/vtab.html#the_xdisconnect_method>
@@ -1015,6 +1064,7 @@ unsafe extern "C" fn rust_open<'vtab, T: 'vtab>(
 where
     T: VTab<'vtab>,
 {
+    guard_vtab(vtab, || {
     let vt = vtab.cast::<T>();
     match (*vt).open() {
         Ok(cursor) => {
@@ -1024,6 +1074,7 @@ where
         }
         Err(err) => err.code(),
     }
+})
 }
 
 // https://www.sqlite.org/vtab.html#the_xupdate_method
@@ -1105,12 +1156,14 @@ unsafe extern "C" fn rust_update<'vtab, T: 'vtab>(
 where
     T: VTabWriteable<'vtab>,
 {
+    guard_vtab(vtab, || {
     let vt = vtab.cast::<T>();
 
     match (*vt).update(determine_update_operation(argc, argv), p_rowid) {
         Ok(_) => SQLITE_OKAY,
         Err(err) => err.code(),
     }
+})
 }
 
 /// <https://www.sqlite.org/vtab.html#the_xbegin_method>
@@ -1216,6 +1269,7 @@ unsafe extern "C" fn rust_filter<C>(
 where
     C: VTabCursor,
 {
+    guard_vtab((*cursor).pVtab, || {
     use std::str;
     let idx_name = if idx_str.is_null() {
         None
@@ -1237,6 +1291,7 @@ where
             err.code()
         }
     }
+})
 }
 
 /// <https://www.sqlite.org/vtab.html#the_xnext_method>
@@ -1245,6 +1300,7 @@ unsafe extern "C" fn rust_next<C>(cursor: *mut sqlite3_vtab_cursor) -> c_int
 where
     C: VTabCursor,
 {
+    guard_vtab((*cursor).pVtab, || {
     let cr = cursor.cast::<C>();
     //cursor_error(cursor, (*cr).next())
     match (*cr).next() {
@@ -1258,6 +1314,7 @@ where
             err.code()
         }
     }
+})
 }
 
 /// <https://www.sqlite.org/vtab.html#the_xeof_method>
@@ -1266,8 +1323,10 @@ unsafe extern "C" fn rust_eof<C>(cursor: *mut sqlite3_vtab_cursor) -> c_int
 where
     C: VTabCursor,
 {
+    guard_vtab((*cursor).pVtab, || {
     let cr = cursor.cast::<C>();
     (*cr).eof() as c_int
+})
 }
 
 /// <https://www.sqlite.org/vtab.html#the_xcolumn_method>
@@ -1280,6 +1339,7 @@ unsafe extern "C" fn rust_column<C>(
 where
     C: VTabCursor,
 {
+    guard_vtab((*cursor).pVtab, || {
     let cr = cursor.cast::<C>();
     //result_error(ctx, (*cr).column(&mut ctxt, i))
     match (*cr).column(ctx, i) {
@@ -1293,6 +1353,7 @@ where
             err.code()
         }
     }
+})
 }
 
 /// "A successful invocation of this method will cause *pRowid to be filled with the rowid of row
@@ -1304,6 +1365,7 @@ unsafe extern "C" fn rust_rowid<C>(cursor: *mut sqlite3_vtab_cursor, p_rowid: *m
 where
     C: VTabCursor,
 {
+    guard_vtab((*cursor).pVtab, || {
     let cr = cursor.cast::<C>();
     match (*cr).rowid() {
         Ok(rowid) => {
@@ -1312,4 +1374,5 @@ where
         }
         Err(err) => err.code(),
     }
+})
 }

--- a/tests/test_panic_guard.rs
+++ b/tests/test_panic_guard.rs
@@ -1,0 +1,105 @@
+//! A panic inside a scalar function or a virtual-table callback becomes an
+//! SQLite error instead of unwinding across the C boundary.
+
+use sqlite_loadable::prelude::*;
+use sqlite_loadable::table::{ConstraintOperator, IndexInfo, VTab, VTabArguments, VTabCursor};
+use sqlite_loadable::{define_scalar_function, define_table_function, BestIndexError, Result};
+use std::os::raw::c_int;
+
+fn t_panic(_context: *mut sqlite3_context, _values: &[*mut sqlite3_value]) -> Result<()> {
+    panic!("scalar boom");
+}
+
+#[repr(C)]
+struct PanicTable {
+    base: sqlite3_vtab,
+}
+impl<'vtab> VTab<'vtab> for PanicTable {
+    type Aux = ();
+    type Cursor = PanicCursor;
+    fn connect(
+        _db: *mut sqlite3,
+        _aux: Option<&Self::Aux>,
+        _args: VTabArguments,
+    ) -> Result<(String, Self)> {
+        Ok((
+            "create table x(value)".to_owned(),
+            PanicTable { base: unsafe { std::mem::zeroed() } },
+        ))
+    }
+    fn best_index(&self, info: IndexInfo) -> core::result::Result<(), BestIndexError> {
+        for mut c in info.constraints() {
+            if c.usable() && c.op() == Some(ConstraintOperator::EQ) {
+                c.set_omit(true);
+                c.set_argv_index(1);
+            }
+        }
+        Ok(())
+    }
+    fn open(&mut self) -> Result<Self::Cursor> {
+        Ok(PanicCursor { base: unsafe { std::mem::zeroed() } })
+    }
+}
+#[repr(C)]
+struct PanicCursor {
+    base: sqlite3_vtab_cursor,
+}
+impl VTabCursor for PanicCursor {
+    fn filter(&mut self, _idx_num: c_int, _idx_str: Option<&str>, _args: &[*mut sqlite3_value]) -> Result<()> {
+        panic!("filter boom");
+    }
+    fn next(&mut self) -> Result<()> {
+        Ok(())
+    }
+    fn eof(&self) -> bool {
+        true
+    }
+    fn column(&self, _context: *mut sqlite3_context, _i: c_int) -> Result<()> {
+        Ok(())
+    }
+    fn rowid(&self) -> Result<i64> {
+        Ok(0)
+    }
+}
+
+#[sqlite_entrypoint]
+pub fn sqlite3_panictest_init(db: *mut sqlite3) -> Result<()> {
+    define_scalar_function(db, "t_panic", 0, t_panic, FunctionFlags::UTF8)?;
+    define_table_function::<PanicTable>(db, "t_panic_table", None)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::{ffi::sqlite3_auto_extension, Connection};
+
+    fn conn() -> Connection {
+        unsafe {
+            sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite3_panictest_init as *const (),
+            )));
+        }
+        Connection::open_in_memory().unwrap()
+    }
+    fn err(db: &Connection, sql: &str) -> String {
+        db.query_row(sql, [], |r| r.get::<_, i64>(0)).unwrap_err().to_string()
+    }
+
+    #[test]
+    fn scalar_panic_is_an_error() {
+        let db = conn();
+        let e = err(&db, "select t_panic()");
+        assert!(e.contains("panic: scalar boom"), "{}", e);
+        // the connection is still usable afterwards
+        assert_eq!(db.query_row("select 1", [], |r| r.get::<_, i64>(0)).unwrap(), 1);
+    }
+
+    #[test]
+    fn vtab_panic_is_an_error() {
+        let db = conn();
+        let e = err(&db, "select value from t_panic_table");
+        assert!(e.contains("panic: filter boom"), "{}", e);
+        assert_eq!(db.query_row("select 1", [], |r| r.get::<_, i64>(0)).unwrap(), 1);
+    }
+}


### PR DESCRIPTION
<!-- Human summary goes here before review -->

<details>
<summary>🤖 Claude-generated PR description</summary>

Every scalar-function wrapper and every virtual-table shim (`xCreate`, `xConnect`, `xBestIndex`, `xOpen`, `xFilter`, `xNext`, `xEof`, `xColumn`, `xRowid`, `xUpdate`) now runs the user callback under `catch_unwind`. A Rust panic becomes `SQLITE_ERROR` with `panic: <message>` (on the function context, the vtab's `zErrMsg`, or `*pzErr` for create/connect) instead of unwinding across the C boundary and aborting the host process.

Also in the scalar-with-aux wrappers: the aux pointer is now borrowed rather than round-tripped through `Box::from_raw` / `Box::into_raw` on every call. Same semantics, fewer footguns.

**Review notes**
- `panic_message` in `table.rs` is `pub(crate)` and shared with `scalar.rs`.
- `tests/test_panic_guard.rs` covers a panicking scalar and a panicking `xFilter`, and checks the connection is still usable afterwards.
- Stacked on `pr/errmsg-plumbing` only because both touch `rust_create` / `rust_connect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeJ1M1czEyy2mnbLFJ8Hon

</details>
