### PR TITLE
scan_config: replacement-scan registry helper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod errors;
 
 #[cfg(feature = "exec")]
 pub mod exec;
+#[cfg(feature = "exec")]
+pub mod scan_config;
 pub mod ext; // TODO dont expose
 pub mod prelude;
 pub mod scalar;

--- a/src/scan_config.rs
+++ b/src/scan_config.rs
@@ -1,0 +1,98 @@
+//! Replacement-scan hints: tell a hosting shell which files this extension
+//! can read.
+//!
+//! Hosts like solite create a per-connection temp table *before* extensions
+//! are loaded:
+//!
+//! ```sql
+//! create table temp._solite_replacement_scan_config (
+//!   vtab_module  text not null,              -- bare module name
+//!   file_pattern text not null,              -- lowercase GLOB, e.g. '*.csv'
+//!   module_args  text not null default '',   -- appended to the USING clause
+//!   remote       integer not null default 0, -- 1 = module accepts URLs
+//!   primary key (vtab_module, file_pattern) on conflict replace
+//! );
+//! ```
+//!
+//! When a query then references an unknown table whose name matches a
+//! registered pattern (`select * from "data/report.xlsx"`), the host creates
+//! `create virtual table temp."<name>" using <vtab_module><module_args>` and
+//! retries. An extension declares its patterns by calling [`register`] from
+//! its entrypoint; under a host that didn't create the table this is a
+//! silent no-op, so the same compiled extension works everywhere.
+//!
+//! C extensions implement the same convention with a single ignored-error
+//! `sqlite3_exec` of the INSERT (see sqlite-source.h's sibling docs):
+//!
+//! ```c
+//! /* replacement-scan hints for hosts like solite; no-op elsewhere */
+//! sqlite3_exec(db,
+//!   "insert or replace into temp._solite_replacement_scan_config"
+//!   "(vtab_module, file_pattern, module_args, remote)"
+//!   " values ('xml0','*.xml','',0),('xml0','*.rss','',0)", 0, 0, 0);
+//! ```
+
+use crate::exec::Statement;
+use crate::ext::sqlite3;
+use crate::{Error, Result};
+
+/// The registry's table name; the host owns creation, extensions only insert.
+pub const SCAN_CONFIG_TABLE: &str = "temp._solite_replacement_scan_config";
+
+/// Whether the module can be pointed at remote URLs (source-API consumers)
+/// or only at local files.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Remote {
+    LocalOnly,
+    RemoteOk,
+}
+
+/// Insert replacement-scan patterns for `module`, all sharing `module_args`
+/// (`""` for none, otherwise a parenthesized suffix like `"(flexible=true)"`).
+/// Silent no-op when the host didn't create the registry table. Call from the
+/// extension entrypoint, after the module is registered.
+pub fn register(
+    db: *mut sqlite3,
+    module: &str,
+    patterns: &[&str],
+    module_args: &str,
+    remote: Remote,
+) -> Result<()> {
+    if !module
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+        || module.is_empty()
+    {
+        return Err(Error::new_message(format!(
+            "invalid vtab module name: {:?}",
+            module
+        )));
+    }
+    // Preparing the INSERT doubles as the probe: it fails with
+    // "no such table" on hosts without the registry.
+    let sql = format!(
+        "insert or replace into {} (vtab_module, file_pattern, module_args, remote) \
+         values (?1, ?2, ?3, ?4)",
+        SCAN_CONFIG_TABLE
+    );
+    let remote = matches!(remote, Remote::RemoteOk) as i32;
+    for pattern in patterns {
+        let mut stmt = match Statement::prepare(db, &sql) {
+            Ok(stmt) => stmt,
+            Err(_) => return Ok(()), // host has no registry table
+        };
+        stmt.bind_text(1, module)
+            .and_then(|_| stmt.bind_text(2, &pattern.to_ascii_lowercase()))
+            .and_then(|_| stmt.bind_text(3, module_args))
+            .and_then(|_| stmt.bind_i32(4, remote))
+            .map_err(|e| Error::new_message(e.to_string()))?;
+        let rc = unsafe { crate::ext::sqlite3ext_step(stmt.as_ptr()) };
+        if rc != crate::constants::SQLITE_DONE {
+            return Err(Error::new_message(format!(
+                "registering replacement-scan pattern {:?} failed (rc={})",
+                pattern, rc
+            )));
+        }
+    }
+    Ok(())
+}

--- a/tests/test_scan_config.rs
+++ b/tests/test_scan_config.rs
@@ -1,0 +1,82 @@
+//! `sqlite_loadable::scan_config::register`: silent no-op without the host's
+//! registry table, idempotent inserts with lowercased patterns when it exists.
+#![cfg(feature = "exec")]
+
+use sqlite_loadable::prelude::*;
+use sqlite_loadable::{api, define_scalar_function, scan_config, Result};
+
+/// Registers scan-config patterns the way an extension entrypoint would.
+fn t_register_scans(context: *mut sqlite3_context, _values: &[*mut sqlite3_value]) -> Result<()> {
+    let db = api::context_db_handle(context);
+    scan_config::register(
+        db,
+        "memcsv",
+        &["*.csv", "*.CSV.GZ"],
+        "(flexible=true)",
+        scan_config::Remote::RemoteOk,
+    )?;
+    api::result_text(context, "ok")?;
+    Ok(())
+}
+
+#[sqlite_entrypoint]
+pub fn sqlite3_scanconfigtest_init(db: *mut sqlite3) -> Result<()> {
+    define_scalar_function(db, "t_register_scans", 0, t_register_scans, FunctionFlags::UTF8)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::{ffi::sqlite3_auto_extension, Connection};
+
+    fn conn() -> Connection {
+        unsafe {
+            sqlite3_auto_extension(Some(std::mem::transmute(
+                sqlite3_scanconfigtest_init as *const (),
+            )));
+        }
+        Connection::open_in_memory().unwrap()
+    }
+    fn q<T: rusqlite::types::FromSql>(db: &Connection, sql: &str) -> T {
+        db.query_row(sql, [], |r| r.get(0)).unwrap()
+    }
+
+    #[test]
+    fn scan_config_register() {
+        let db = conn();
+        // no registry table: silent no-op
+        assert_eq!(q::<String>(&db, "select t_register_scans()"), "ok");
+        db.execute_batch(
+            "create table temp._solite_replacement_scan_config (
+               vtab_module  text not null,
+               file_pattern text not null,
+               module_args  text not null default '',
+               remote       integer not null default 0,
+               primary key (vtab_module, file_pattern) on conflict replace
+             );",
+        )
+        .unwrap();
+        assert_eq!(q::<String>(&db, "select t_register_scans()"), "ok");
+        // registering twice is idempotent thanks to the conflict-replace key
+        assert_eq!(q::<String>(&db, "select t_register_scans()"), "ok");
+        let rows: Vec<(String, String, String, i64)> = db
+            .prepare(
+                "select vtab_module, file_pattern, module_args, remote \
+                 from temp._solite_replacement_scan_config order by file_pattern",
+            )
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                // patterns are lowercased on the way in
+                ("memcsv".into(), "*.csv".into(), "(flexible=true)".into(), 1),
+                ("memcsv".into(), "*.csv.gz".into(), "(flexible=true)".into(), 1),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
<!-- Human summary goes here before review -->

<details>
<summary>🤖 Claude-generated PR description</summary>

Adds `sqlite_loadable::scan_config::register` (gated on the `exec` feature): a helper for extensions to advertise which file patterns their virtual-table module can read, for hosts that implement replacement scans.

Hosts like solite create `temp._solite_replacement_scan_config` before loading extensions; when a query names an unknown table matching a registered pattern (`select * from "data/report.xlsx"`) the host creates the vtab and retries. `register(db, module, patterns, module_args, Remote::…)` inserts the rows, lowercasing patterns; under a host that did not create the table it is a silent no-op, so the same binary works everywhere. The module doc carries the equivalent one-line `sqlite3_exec` for C extensions.

`tests/test_scan_config.rs` covers the no-op case, the insert, and idempotency via the table's `on conflict replace` key.

Stacked on `pr/errmsg-plumbing` (uses `Statement::as_ptr`). Adjacent-line conflict with `pr/source-api` in `src/lib.rs`: whichever merges second needs a trivial rebase. Downstream users today: sqlite-xsv, sqlite-parquet, sqlite-json-reader (sqlite-xl hand-writes the same INSERT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeJ1M1czEyy2mnbLFJ8Hon

</details>
